### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 The Snirk Language Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
I've looked over the major open source licenses and I think that the MIT license is the way to go. I really like the fact that it doesn't need to define a lot of terms like Apache and the GPL do, and I feel it's quite permissive.

There are four parties (generally) who care about a project's open source license - the core development team, contributors, authors of the project's dependencies, and end users.

As the current sole member of the core development team, I think the MIT license is a good choice. I want us to send a clear message that this code is open to the public with a very clear and straightforward license.

The MIT license sends a strong message to contributors that this project is copyleft and permissive in its usage. Although we want to encourage open-source contribution, a more permissive license can discourage potential contributors who feel that their contributions will not be protected. An example of this is Google which is notorious for seeking copyright in all endeavours of its employees. Looking through Rust's source, Google has copyright in RLS (the Rust Language Server), `libbacktrace`, and the Rust Book.

Right now, the only major dependency we have is LLVM, and they have a permissive license. All of our Rust dependencies are dual Apache/MIT. 

Finally, I think the MIT license will be permissive enough to be embraced by users of open-source code. We can enable other open source developers and businesses alike to feel comfortable using the programming language or code from the project.

I'm not going to merge this PR right away in order to read up on licenses more, paste copyright text into the source files, and add a CI script to check for the copyright text. 

Closes #48.