### PR TITLE
Add boolean literals

### DIFF
--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -42,12 +42,10 @@ pub fn compile<'ctx>(input: &'static str,
 }
 
 pub const COMPILE_EXAMPLE: &str = r#"
-fn foo() -> float
-    do
-        1
+fn foo() -> bool
+    true
 "#;
 
-#[ignore]
 #[test]
 fn compile_example() {
     ::env_logger::Builder::new().parse("TRACE").init();

--- a/src/parse/symbol/expression/identifier.rs
+++ b/src/parse/symbol/expression/identifier.rs
@@ -2,7 +2,7 @@
 
 // This is gonna be merged with lvalue parsers
 
-use lex::{Token, Tokenizer};
+use lex::{Token, TokenData, Tokenizer};
 use parse::{Parser, ParseResult};
 use ast::*;
 use parse::symbol::PrefixParser;
@@ -17,8 +17,18 @@ use parse::symbol::PrefixParser;
 #[derive(Debug)]
 pub struct IdentifierParser { }
 impl<T: Tokenizer> PrefixParser<Expression, T> for IdentifierParser {
-    fn parse(&self, _parser: &mut Parser<T>, token: Token) -> ParseResult<Expression> {
-        Ok(Expression::VariableRef(Identifier::new(token)))
+    fn parse(&self, _parser: &mut Parser<T>, mut token: Token) -> ParseResult<Expression> {
+        if token.text() == "true" {
+            token.data = TokenData::BoolLiteral(true);
+            Ok(Expression::Literal(Literal::new(token, LiteralValue::Bool(true))))
+        }
+        else if token.text() == "false" {
+            token.data = TokenData::BoolLiteral(false);
+            Ok(Expression::Literal(Literal::new(token, LiteralValue::Bool(false))))
+        }
+        else {
+            Ok(Expression::VariableRef(Identifier::new(token)))
+        }
     }
 }
 


### PR DESCRIPTION
Adds `true` and `false` as boolean literals. It's kind of hacky - they're initially lexed as identifiers but they're later parsed as literals. The tweaking of a token by the parser is unfortunate, but should be okay for now. This can be redone in a future AST structure and eventually boolean literals could be moved out of the parsing level.