### PR TITLE
Set native platform info on LLVM modules

### DIFF
--- a/src/compile/module_compiler.rs
+++ b/src/compile/module_compiler.rs
@@ -170,11 +170,11 @@ impl<'ctx, 'b, M> ItemVisitor for ModuleCompiler<'ctx, 'b, M>
 
 
         if !fn_ref.verify(LLVMVerifierFailureAction::LLVMPrintMessageAction) {
-            info!("Function IR:");
-            fn_ref.dump();
+            error!("Failed to verify {}", block_fn.name());
+            error!("Current module IR:\n{}", self.current_module().print_to_string());
             panic!("Validation error for {}", block_fn.name());
         }
-        
+
         if self.optimizations {
             trace!("Running optimizations on fn {}", block_fn.name());
             self.module_provider.pass_manager().run(&fn_ref);

--- a/src/compile/module_provider.rs
+++ b/src/compile/module_provider.rs
@@ -24,6 +24,7 @@ impl<'ctx> SimpleModuleProvider<'ctx> {
         }
         else if let Ok(layout) = layout {
             module.set_data_layout(&layout);
+            module.set_target_triple(&llvm::target::native_target_triple());
         }
 
         let pass_manager = FunctionPassManager::new(&module);

--- a/src/llvm/context.rs
+++ b/src/llvm/context.rs
@@ -23,8 +23,6 @@ impl Drop for Context {
 }
 
 impl Context {
-    // Can't use `llvm_methods` due to no lifetime needs :)
-
     pub unsafe fn from_ref(ptr: LLVMContextRef) -> Context {
         Context { ptr }
     }

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -92,3 +92,4 @@ pub mod types;
 pub use self::types::Type;
 pub mod pass_manager;
 pub use self::pass_manager::{PassManager, FunctionPassManager};
+pub mod target;

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -93,3 +93,6 @@ pub use self::types::Type;
 pub mod pass_manager;
 pub use self::pass_manager::{PassManager, FunctionPassManager};
 pub mod target;
+pub use self::target::{initialize_all_targets,
+                       initialize_native_target,
+                       Target, TargetData, TargetMachine};

--- a/src/llvm/module.rs
+++ b/src/llvm/module.rs
@@ -99,6 +99,13 @@ impl<'ctx> Module<'ctx> {
         }
     }
 
+    pub fn set_target_triple(&self, target_triple: &str) {
+        let c_name = CString::new(target_triple).unwrap();
+        unsafe {
+            LLVMSetTarget(self.ptr(), c_name.as_ptr());
+        }
+    }
+
     pub fn verify(&self,
                   action: LLVMVerifierFailureAction) -> Result<(), String> {
         let mut error = 0 as *mut c_char;

--- a/src/llvm/module.rs
+++ b/src/llvm/module.rs
@@ -8,8 +8,9 @@ use libc::c_char;
 use llvm_sys::core::*;
 use llvm_sys::prelude::*;
 use llvm_sys::analysis::{LLVMVerifierFailureAction, LLVMVerifyModule};
+use llvm_sys::target::{LLVMSetModuleDataLayout};
 
-use llvm::{Type, Value};
+use llvm::{Type, Value, TargetData};
 
 /// Handle to an LLVM Module. Owned by an LLVM Context.
 #[derive(Debug, Clone)]
@@ -92,6 +93,11 @@ impl<'ctx> Module<'ctx> {
         }
     }
 
+    pub fn set_data_layout(&self, target_data: &TargetData) {
+        unsafe {
+            LLVMSetModuleDataLayout(self.ptr(), target_data.ptr())
+        }
+    }
 
     pub fn verify(&self,
                   action: LLVMVerifierFailureAction) -> Result<(), String> {

--- a/src/llvm/target.rs
+++ b/src/llvm/target.rs
@@ -1,0 +1,226 @@
+//! Bindings to LLVM target methods
+
+use std::ffi::{CStr, CString};
+use libc::c_char;
+
+use llvm_sys::core::LLVMDisposeMessage;
+use llvm_sys::target::*;
+use llvm_sys::target_machine::*;
+
+pub fn initialize_native_target() -> bool {
+    unsafe {
+        if LLVM_InitializeNativeTarget() == 1 {
+            return false
+        }
+        return true
+    }
+}
+
+pub fn initialize_all_targets() {
+    unsafe {
+        LLVM_InitializeAllTargets()
+    }
+}
+
+pub fn native_target_triple() -> String {
+    unsafe {
+        let buf = LLVMGetDefaultTargetTriple();
+        let cstr_buf = CStr::from_ptr(buf);
+        let result = String::from_utf8_lossy(cstr_buf.to_bytes()).into_owned();
+        LLVMDisposeMessage(buf);
+        result
+    }
+}
+
+pub fn native_cpu_name() -> String {
+    unsafe {
+        let buf = LLVMGetHostCPUName();
+        let cstr_buf = CStr::from_ptr(buf);
+        let result = String::from_utf8_lossy(cstr_buf.to_bytes()).into_owned();
+        LLVMDisposeMessage(buf);
+        result
+    }
+}
+
+pub fn native_cpu_features() -> String {
+    unsafe {
+        let buf = LLVMGetHostCPUFeatures();
+        let cstr_buf = CStr::from_ptr(buf);
+        let result = String::from_utf8_lossy(cstr_buf.to_bytes()).into_owned();
+        LLVMDisposeMessage(buf);
+        result
+    }
+}
+
+pub struct Target {
+    ptr: LLVMTargetRef
+}
+
+impl_llvm_ptr_fmt!(Target);
+
+impl Target {
+    pub unsafe fn from_ref(ptr: LLVMTargetRef) -> Target {
+        Target { ptr }
+    }
+    pub fn ptr(&self) -> LLVMTargetRef {
+        self.ptr
+    }
+
+    pub fn first() -> Target {
+        unsafe {
+            Target::from_ref(LLVMGetFirstTarget())
+        }
+    }
+
+    pub fn next(&self) -> Option<Target> {
+        let ptr = unsafe {
+            LLVMGetNextTarget(self.ptr())
+        };
+        if ptr.is_null() {
+            None
+        }
+        else {
+            Some(unsafe { Target::from_ref(ptr) })
+        }
+    }
+
+    pub fn from_triple(triple: &str) -> Result<Target, String> {
+        let mut first_ptr = Target::first().ptr;
+        let triple_str = CString::new(triple).unwrap();
+        let mut error_ptr = 0 as *mut c_char;
+        let result = unsafe {
+            LLVMGetTargetFromTriple(triple_str.as_ptr(),
+                                    &mut first_ptr as *mut LLVMTargetRef,
+                                    &mut error_ptr)
+        };
+        if result != 0 {
+            unsafe {
+            let cstr_buf = CStr::from_ptr(error_ptr);
+            let error = String::from_utf8_lossy(cstr_buf.to_bytes())
+                                .into_owned();
+            LLVMDisposeMessage(error_ptr);
+            Err(error)
+            }
+        }
+        else {
+            Ok(unsafe { Target::from_ref(first_ptr) })
+        }
+    }
+
+    pub fn native() -> Result<Target, String> {
+        Target::from_triple(&native_target_triple())
+    }
+
+    pub fn get_name(&self) -> String {
+        unsafe {
+            let buf = LLVMGetTargetName(self.ptr());
+            let cstr_buf = CStr::from_ptr(buf);
+            let result = String::from_utf8_lossy(cstr_buf.to_bytes()).into_owned();
+            result
+        }
+    }
+
+
+    pub fn get_description(&self) -> String {
+        unsafe {
+            let buf = LLVMGetTargetDescription(self.ptr());
+            let cstr_buf = CStr::from_ptr(buf);
+            let result = String::from_utf8_lossy(cstr_buf.to_bytes()).into_owned();
+            result
+        }
+    }
+}
+
+pub struct TargetData {
+    ptr: LLVMTargetDataRef
+}
+
+impl_llvm_ptr_fmt!(TargetData);
+
+impl Drop for TargetData {
+    fn drop(&mut self) {
+        unsafe {
+            LLVMDisposeTargetData(self.ptr());
+        }
+    }
+}
+
+impl TargetData {
+    pub unsafe fn from_ref(ptr: LLVMTargetDataRef) -> TargetData {
+        TargetData { ptr }
+    }
+
+    pub fn ptr(&self) -> LLVMTargetDataRef {
+        self.ptr
+    }
+
+    /// # Panics
+    /// Will abort if given an unknown target layout
+    pub fn from_target_layout(layout: &str) -> TargetData {
+        let c_str = CString::new(layout).unwrap();
+        unsafe {
+            TargetData::from_ref(
+                LLVMCreateTargetData(c_str.as_ptr() as *const c_char)
+            )
+        }
+    }
+}
+
+pub struct TargetMachine {
+    ptr: LLVMTargetMachineRef
+}
+
+impl_llvm_ptr_fmt!(TargetMachine);
+
+impl Drop for TargetMachine {
+    fn drop(&mut self) {
+        unsafe {
+            LLVMDisposeTargetMachine(self.ptr());
+        }
+    }
+}
+
+impl TargetMachine {
+    pub unsafe fn from_ref(ptr: LLVMTargetMachineRef) -> TargetMachine {
+        TargetMachine { ptr }
+    }
+    pub fn ptr(&self) -> LLVMTargetMachineRef {
+        self.ptr
+    }
+
+    pub fn new(target: &Target,
+               triple: &str,
+               cpu: &str,
+               features: &str,
+               opt_level: LLVMCodeGenOptLevel,
+               reloc_mode: LLVMRelocMode,
+               code_model: LLVMCodeModel) -> TargetMachine {
+        let triple_str = CString::new(triple).unwrap();
+        let cpu_str = CString::new(cpu).unwrap();
+        let features_str = CString::new(features).unwrap();
+        unsafe {
+            TargetMachine::from_ref(
+                LLVMCreateTargetMachine(target.ptr(),
+                                        triple_str.as_ptr(),
+                                        cpu_str.as_ptr(),
+                                        features_str.as_ptr(),
+                                        opt_level,
+                                        reloc_mode,
+                                        code_model))
+        }
+    }
+
+    pub fn native(opt_level: LLVMCodeGenOptLevel,
+                  reloc_mode: LLVMRelocMode,
+                  code_model: LLVMCodeModel) -> Result<TargetMachine, String> {
+        let native_target = try!(Target::native());
+
+        Ok(TargetMachine::new(&native_target,
+                              &native_target_triple(),
+                              &native_cpu_name(),
+                              &native_cpu_features(),
+                              opt_level,
+                              reloc_mode,
+                              code_model))
+    }
+}

--- a/src/llvm/target.rs
+++ b/src/llvm/target.rs
@@ -164,6 +164,19 @@ impl TargetData {
             )
         }
     }
+
+    pub fn from_machine(machine: &TargetMachine) -> TargetData {
+        unsafe {
+            TargetData::from_ref(LLVMCreateTargetDataLayout(machine.ptr()))
+        }
+    }
+
+    pub fn native(opt_level: LLVMCodeGenOptLevel,
+                  reloc_mode: LLVMRelocMode,
+                  code_model: LLVMCodeModel) -> Result<TargetData, String> {
+        let machine = try!(TargetMachine::native(opt_level, reloc_mode, code_model));
+        Ok(TargetData::from_machine(&machine))
+    }
 }
 
 pub struct TargetMachine {

--- a/src/llvm/value.rs
+++ b/src/llvm/value.rs
@@ -1,6 +1,6 @@
 //! Bindings to LLVM value objects
 
-use std::ffi::CString;
+use std::ffi::{CString, CStr};
 use std::mem;
 
 use libc::{size_t, c_uint};
@@ -73,6 +73,16 @@ impl<'ctx> Value<'ctx> {
     pub fn dump(&self) {
         unsafe {
             LLVMDumpValue(self.ptr());
+        }
+    }
+
+    pub fn print_to_string(&self) -> String {
+        unsafe {
+            let buf = LLVMPrintValueToString(self.ptr());
+            let cstr_buf = CStr::from_ptr(buf);
+            let result = String::from_utf8_lossy(cstr_buf.to_bytes()).into_owned();
+            LLVMDisposeMessage(buf);
+            result
         }
     }
 


### PR DESCRIPTION
This PR sets the data layout for modules to use the native data layout on LLVM modules. I've taken the liberty of renaming the bindings to use the word `native`. This enables better LLVM optimizations (although they're probably not relevant right now).

This does not `fix` #93. I'm going to merge anyway as this setting native target info is [recommended by LLVM](https://llvm.org/docs/Frontend/PerformanceTips.html#the-basics).

Here's an example of the module metadata (Linux on an x86, 64 bit Intel processor):

```llvm
; ModuleID = 'if-expr-ok'
source_filename = "if-expr-ok"
target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-pc-linux-gnu"
```