### PR TITLE
ScopedID duplication in functions

### DIFF
--- a/derive_integration_tests/src/lib.rs
+++ b/derive_integration_tests/src/lib.rs
@@ -98,8 +98,6 @@ fn create_tests(path: &Path, mut path_name: Ident) -> quote::__rt::TokenStream {
 
 #[proc_macro_derive(IntegrationTests)]
 pub fn create_integration_tests(input: TokenStream) -> TokenStream {
-    let _ast: DeriveInput = syn::parse(input).unwrap();
-
     let full_path = env::current_dir()
         .expect("Can't `pwd`")
         .join("tests");

--- a/src/check/types/type_concretifier.rs
+++ b/src/check/types/type_concretifier.rs
@@ -1,4 +1,4 @@
-//! Run type inference to produce a mapping of the actual conrete types of
+//! Run type inference to produce a mapping of the actual concrete types of
 //! things.
 
 use lex::Token;
@@ -105,7 +105,7 @@ impl<'err, 'builder, 'graph> ItemVisitor
     fn visit_block_fn_decl(&mut self, block_fn: &BlockFnDeclaration) {
         trace!("Visiting declaration of fn {}", block_fn.name());
         self.infer_var(&block_fn.id(), block_fn.token(),
-            format!("fn declaration {}", block_fn.name()));
+            format!("fn {}", block_fn.name()));
 
         for &(ref param, ref _param_ty) in block_fn.params() {
             trace!("Inferring the type of {} param {}",
@@ -203,6 +203,7 @@ impl<'err, 'builder, 'graph> ExpressionVisitor
     }
 
     fn visit_assignment(&mut self, assign: &Assignment) {
+        trace!("Visiting assignment to {}", assign.lvalue().name());
         self.visit_expression(assign.rvalue());
         self.infer_var(&assign.lvalue().id(),
             assign.lvalue().token(),
@@ -211,6 +212,7 @@ impl<'err, 'builder, 'graph> ExpressionVisitor
     }
 
     fn visit_declaration(&mut self, decl: &Declaration) {
+        trace!("Visiting declaration of {}", decl.name());
         self.visit_expression(decl.value());
         self.infer_var(&decl.id(), decl.token(),
             format!("definition of variable {}", decl.token()));

--- a/src/identify/names/item_namer.rs
+++ b/src/identify/names/item_namer.rs
@@ -63,7 +63,12 @@ impl<'err, 'builder> ItemVisitor for ItemVarIdentifier<'err, 'builder> {
         block_fn.set_id(fn_id);
 
         // Also name the params, in a new scope.
+        // Consider a function with ID [..., n]:
+        // - its top level scope will be [..., n, 0]
+        // - its p params will be [..., n, 1] through [..., n, p]
+        // - its v local vars will be [..., n, 0, 0] through [..., n, 0, v]
         self.current_id.push();
+        self.current_id.increment();
         self.builder.new_scope();
 
         // One of the consequences of setting params here is that we know the

--- a/src/identify/types/mod.rs
+++ b/src/identify/types/mod.rs
@@ -42,15 +42,8 @@ impl<'builder, 'graph, 'err> UnitVisitor
     for ASTTypeChecker<'builder, 'graph, 'err> {
 
     fn visit_unit(&mut self, unit: &Unit) {
-        trace!("Visting unit");
-        debug!("Calling ItemTypeIdentifier");
-        ItemTypeIdentifier::new(self.errors, self.builder)
-                           .visit_unit(unit);
         debug!("Calling ItemTypographer");
         ItemTypographer::new(self.builder, self.errors, self.graph)
-                        .visit_unit(unit);
-        debug!("Calling ExprTypeIdentifier");
-        ExprTypeIdentifier::new(self.errors, self.builder)
                         .visit_unit(unit);
         debug!("Calling ExprTypographer");
         ExprTypographer::new(self.builder, self.errors, self.graph)

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -18,11 +18,13 @@ use std::io::{self, Read};
 #[derive(Debug)]
 pub enum CompilationError {
     IdentificationError {
+        unit: Unit,
         name_builder: NameScopeBuilder,
         type_builder: TypeScopeBuilder,
         errors: ErrorCollector
     },
     CheckingError {
+        unit: Unit,
         type_builder: TypeScopeBuilder,
         graph: TypeGraph,
         errors: ErrorCollector
@@ -86,6 +88,7 @@ impl IdentifyRunner {
         if !self.errors.errors().is_empty() {
             error!("IdentifyRunner: failed ASTIdentifer");
             return Err(CompilationError::IdentificationError {
+                unit: self.unit,
                 name_builder: self.name_builder,
                 type_builder: self.type_builder,
                 errors: self.errors
@@ -98,6 +101,7 @@ impl IdentifyRunner {
         if !self.errors.errors().is_empty() {
             error!("IdentifyRunner: failed ASTTypeChecker");
             Err(CompilationError::CheckingError {
+                unit: self.unit,
                 type_builder: self.type_builder,
                 graph: self.graph,
                 errors: self.errors
@@ -142,6 +146,7 @@ impl CheckRunner {
         if !self.errors.errors().is_empty() {
             error!("CheckRunner: failed to type concretify");
             Err(CompilationError::CheckingError {
+                unit: self.unit,
                 type_builder: self.type_builder,
                 graph: self.graph,
                 errors: self.errors

--- a/tests/compile/item/fn/fn-params-and-vars-have-ids-ok.protosnirk
+++ b/tests/compile/item/fn/fn-params-and-vars-have-ids-ok.protosnirk
@@ -1,0 +1,9 @@
+/// A test which attempts to confirm that variables all have unique IDs.
+/// We create a function with a different return type from its arguments and a
+/// couple of local variables and if their IDs overlap we may catch it in
+/// type checking.
+
+fn foo(x: float) -> bool
+    let y: bool = true
+    let z: float = 0
+    y

--- a/tests/compile/item/fn/fn-params-return-ok.protosnirk
+++ b/tests/compile/item/fn/fn-params-return-ok.protosnirk
@@ -1,0 +1,4 @@
+// Functions with parameters differing from return type
+
+fn foo(x: float) -> bool
+    true


### PR DESCRIPTION
We were giving the main block of a function the same `ScopedId` as its first parameter. This was only caught during type inference for functions which returned a value as that's when we ended up actually using the `ScopedId` of the block.