### PR TITLE
We can remove `sudo: required` from Travis?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,37 +12,34 @@
 # available at https://github.com/zig-lang/zig
 
 dist: trusty
-sudo: required
+sudo: false
+
+notifications:
+  email: false
 
 git:
   depth: 3
 
 language: rust
 rust:
-  - stable
+- stable
 
 cache:
-  - cargo
+- cargo
 
-notifications:
-  email: false
+addons:
+  apt:
+    packages:
+    - llvm-7
+    - llvm-7-dev
+    - llvm-7-runtime
+    - libllvm7
+    sources:
+    - llvm-toolchain-trusty-7
 
-before_install:
-  - sudo sh -c 'echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-7 main" >> /etc/apt/sources.list'
-  - wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -q
-
-install:
-  - sudo apt-get remove -y llvm-*
-  - sudo rm -rf /usr/local/*
-  - sudo apt-get install -y llvm-7 llvm-7-dev llvm-7-runtime libllvm7
-  # llvm-sys wants to run `llvm-config`
-  - ls /usr/bin/*7*
-  - sudo ln -s /usr/bin/llvm-config-7 /usr/bin/llvm-config
+before_script:
+- llvm-config --version
 
 script:
-  - find /usr/bin -name "*llvm*" | sort
-  - llvm-config --version
-  - cargo check --verbose
-  - cargo test --all --verbose
+- cargo check --verbose
+- cargo test --all --verbose


### PR DESCRIPTION
They've added llvm7 to the apt list and llvm-sys is better about `llvm-config`.