### PR TITLE
Switch travis dist to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@
 # Zig is an MIT-licensed open-source programming language,
 # available at https://github.com/zig-lang/zig
 
-dist: trusty
+dist: xenial
 sudo: false
 
 notifications:


### PR DESCRIPTION
According to [the docs](https://docs.travis-ci.com/user/reference/xenial/), this should speed up our build. We don't use any of travis's built in services (i.e. databases).