### PR TITLE
Use a fixed match statement to parse (closes #31)

### DIFF
--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -4,8 +4,7 @@
 //! source tree.
 
 use std::borrow::Cow;
-use std::collections::{HashMap, VecDeque};
-use std::rc::Rc;
+use std::collections::VecDeque;
 
 use lex::{CowStr, Token, TokenType, Tokenizer};
 use parse::ParseError;
@@ -18,14 +17,6 @@ pub struct Parser<T: Tokenizer> {
     tokenizer: T,
     /// Lookahead queue for peeking
     lookahead: VecDeque<Token>,
-    /// Parsers used for prefix symbols in statements (`return`, `do`)
-    stmt_prefix_parsers: HashMap<TokenType, Rc<PrefixParser<Statement, T> + 'static>>,
-    /// Parsers used for infix symbols in expressions (`+`, `<`)
-    expr_infix_parsers: HashMap<TokenType, Rc<InfixParser<Expression, T> + 'static>>,
-    /// Parsers used for prefix symbols in expressions (`not`, `let`)
-    expr_prefix_parsers: HashMap<TokenType, Rc<PrefixParser<Expression, T> + 'static>>,
-    /// Parses for parsing program items (struct/enum/fn declarations, etc.)
-    item_parsers: HashMap<TokenType, Rc<PrefixParser<Item, T> + 'static>>,
     /// Allows the parser to skip over unneeded indentation
     indent_rules: Vec<IndentationRule>,
 }
@@ -231,36 +222,22 @@ impl<T: Tokenizer> Parser<T> {
         trace!("Parsing expression(precedence={:?}) with {}", precedence, token);
         if _indented { trace!("Parsing indented expression"); }
         let token_type = token.get_type();
+        use self::TokenType::*;
         let mut left = try!(match token_type {
-            TokenType::EOF => {
-                trace!("Unexpected EOF parsing expression");
-                Err(ParseError::EOF)
-            },
-            TokenType::EndBlock => {
-                trace!("Unexpected EndBlock parsing expression");
-                Err(ParseError::EOF)
-            },
-            TokenType::If => {
-                trace!("Parsing an if expression");
-                IfExpressionParser { }.parse(self, token)
-            },
-            TokenType::Minus =>{
-                trace!("Parsing a subtraction expression");
-                UnaryOpExprSymbol::with_precedence(Precedence::NumericPrefix)
-                    .parse(self, token)
-            },
-            TokenType::LeftParen => {
-                trace!("Parsing a paren expression");
-                ParensParser { }.parse(self, token)
-            },
-            TokenType::Ident => {
-                trace!("Parsing an identifier reference");
-                IdentifierParser { }.parse(self, token)
-            },
-            TokenType::Literal => {
-                trace!("Parsing a literal expression");
-                LiteralParser { }.parse(self, token)
-            },
+            EOF => Err(ParseError::EOF),
+
+            EndBlock => Err(ParseError::EOF),
+
+            If => IfExpressionParser { }.parse(self, token),
+
+            Minus | Plus => UnaryOpExprSymbol { }.parse(self, token),
+
+            LeftParen => ParensParser { }.parse(self, token),
+
+            Ident => IdentifierParser { }.parse(self, token),
+
+            Literal => LiteralParser { }.parse(self, token),
+
             _ => {
                 trace!("Could not find parser");
                 return Err(ParseError::LazyString(format!("Unexpected token {:?}", token)))
@@ -275,77 +252,25 @@ impl<T: Tokenizer> Parser<T> {
             token = new_token;
             let token_type = token.get_type();
             left = try!(match token_type {
-                TokenType::Equals => {
-                    trace!("Parsing an assignment");
-                    AssignmentParser { }.parse(self, left, token)
-                },
-                TokenType::Plus => {
-                    trace!("Parsing infix addition");
-                    BinOpExprSymbol::with_precedence(Precedence::AddSub)
-                        .parse(self, left, token)
-                },
-                TokenType::Minus => {
-                    trace!("Parsing infix subtraction");
-                    BinOpExprSymbol::with_precedence(Precedence::AddSub)
-                        .parse(self, left, token)
-                },
-                TokenType::Star => {
-                    trace!("Parsing with multiplication");
-                    BinOpExprSymbol::with_precedence(Precedence::MulDiv)
-                        .parse(self, left, token)
-                },
-                TokenType::Slash => {
-                    trace!("Parsing with division");
-                    BinOpExprSymbol::with_precedence(Precedence::MulDiv)
-                        .parse(self, left, token)
-                },
-                TokenType::Percent => {
-                    trace!("Parsing with modulo");
-                    BinOpExprSymbol::with_precedence(Precedence::Modulo)
-                        .parse(self, left, token)
-                },
-                TokenType::LeftParen => {
-                    trace!("Parsing function call");
-                    FnCallParser { }.parse(self, left, token)
-                },
-                TokenType::LeftAngle => {
-                    trace!("Parsing less than expression");
-                    BinOpExprSymbol::with_precedence(Precedence::EqualityCompare)
-                        .parse(self, left, token)
-                },
-                TokenType::RightAngle => {
-                    trace!("Parsing greater than expression");
-                    BinOpExprSymbol::with_precedence(Precedence::EqualityCompare)
-                        .parse(self, left, token)
-                },
-                TokenType::LessThanEquals => {
-                    trace!("Parsing lte expression");
-                    BinOpExprSymbol::with_precedence(Precedence::EqualityCompare)
-                        .parse(self, left, token)
-                },
-                TokenType::GreaterThanEquals => {
-                    trace!("Parsing gte expression");
-                    BinOpExprSymbol::with_precedence(Precedence::EqualityCompare)
-                        .parse(self, left, token)
-                },
-                TokenType::DoubleEquals => {
-                    trace!("Parsing equality expression");
-                    BinOpExprSymbol::with_precedence(Precedence::Equality)
-                        .parse(self, left, token)
-                },
-                TokenType::NotEquals => {
-                    trace!("Parsing not equals expression");
-                    BinOpExprSymbol::with_precedence(Precedence::Equality)
-                        .parse(self, left, token)
-                },
-                TokenType::PlusEquals
-                | TokenType::MinusEquals
-                | TokenType::StarEquals
-                | TokenType::PercentEquals
-                | TokenType::SlashEquals=> {
-                    trace!("Parsing assign op");
-                    AssignOpParser { }.parse(self, left, token)
-                },
+                Equals => AssignmentParser { }.parse(self, left, token),
+
+                Plus | Minus | Star | Slash | Percent =>
+                    BinOpExprSymbol { }.parse(self, left, token),
+
+                LeftParen => FnCallParser { }.parse(self, left, token),
+
+                LeftAngle | RightAngle =>
+                    BinOpExprSymbol { }.parse(self, left, token),
+
+                LessThanEquals | GreaterThanEquals =>
+                    BinOpExprSymbol { }.parse(self, left, token),
+
+                DoubleEquals | NotEquals =>
+                    BinOpExprSymbol { }.parse(self, left, token),
+
+                PlusEquals | MinusEquals | StarEquals | PercentEquals | SlashEquals =>
+                    AssignOpParser { }.parse(self, left, token),
+
                 _ => {
                     // If we can't match an infix then we need to parse the next
                     // expression.
@@ -361,32 +286,30 @@ impl<T: Tokenizer> Parser<T> {
 
     /// Parse a single statement.
     pub fn statement(&mut self) -> Result<Statement, ParseError> {
+        use self::TokenType::*;
+        trace!("Parsing statement for {:?}", self.next_type());
         match self.next_type() {
             // This may be refactorable with NLL
-            TokenType::Let => {
-                trace!("Parsing let statement");
+            Let => {
                 let token = self.consume();
                 DeclarationParser { }.parse(self, token)
             },
-            TokenType::Return => {
-                trace!("Parsing return statement");
+            Return => {
                 let token = self.consume();
                 ReturnParser { }.parse(self, token)
             },
-            TokenType::Do => {
-                trace!("Parsing do block");
+            Do => {
                 let token = self.consume();
                 DoBlockParser { }.parse(self, token)
             },
-            TokenType::If => {
-                trace!("Parsing an if block");
+            If => {
                 let token = self.consume();
                 IfBlockParser { }.parse(self, token)
             },
             _ => {
                 trace!("Using expr parser for statement");
                 self.expression(Precedence::Min)
-                    .map(Expression::to_statement)
+                    .map(Statement::Expression)
             }
         }
     }
@@ -484,65 +407,9 @@ impl<T: Tokenizer> Parser<T> {
 
     /// Create a new parser from the given tokenizer, initializing its fields to match
     pub fn new(tokenizer: T) -> Parser<T> {
-        use parse::symbol::*;
-        use lex::TokenType::*;
-        let expr_infix_map: HashMap<TokenType, Rc<InfixParser<Expression, T> + 'static>> =
-        hashmap![
-            Equals => Rc::new(AssignmentParser { }) as Rc<InfixParser<Expression, T>>,
-
-            Plus => BinOpExprSymbol::with_precedence(Precedence::AddSub),
-            Minus => BinOpExprSymbol::with_precedence(Precedence::AddSub),
-            Star => BinOpExprSymbol::with_precedence(Precedence::MulDiv),
-            Slash => BinOpExprSymbol::with_precedence(Precedence::MulDiv),
-
-            Percent => BinOpExprSymbol::with_precedence(Precedence::Modulo),
-
-            LeftParen => Rc::new(FnCallParser { }) as Rc<InfixParser<Expression, T>>,
-
-            LeftAngle => BinOpExprSymbol::with_precedence(Precedence::EqualityCompare),
-            RightAngle => BinOpExprSymbol::with_precedence(Precedence::EqualityCompare),
-            LessThanEquals => BinOpExprSymbol::with_precedence(Precedence::EqualityCompare),
-            GreaterThanEquals => BinOpExprSymbol::with_precedence(Precedence::EqualityCompare),
-
-            DoubleEquals => BinOpExprSymbol::with_precedence(Precedence::Equality),
-            NotEquals => BinOpExprSymbol::with_precedence(Precedence::Equality),
-
-            PlusEquals => Rc::new(AssignOpParser { }) as Rc<InfixParser<Expression, T>>,
-            MinusEquals => Rc::new(AssignOpParser { }) as Rc<InfixParser<Expression, T>>,
-            StarEquals => Rc::new(AssignOpParser { }) as Rc<InfixParser<Expression, T>>,
-            PercentEquals => Rc::new(AssignOpParser { }) as Rc<InfixParser<Expression, T>>,
-            SlashEquals => Rc::new(AssignOpParser { }) as Rc<InfixParser<Expression, T>>
-        ];
-        let expr_prefix_map: HashMap<TokenType, Rc<PrefixParser<Expression, T> + 'static>> =
-        hashmap![
-            If => Rc::new(IfExpressionParser { }) as Rc<PrefixParser<Expression, T>>,
-
-            Minus => UnaryOpExprSymbol::with_precedence(Precedence::NumericPrefix),
-            LeftParen => Rc::new(ParensParser { }) as Rc<PrefixParser<Expression, T>>,
-
-            Ident => Rc::new(IdentifierParser { }) as Rc<PrefixParser<Expression, T>>,
-            Literal => Rc::new(LiteralParser { }) as Rc<PrefixParser<Expression, T>>,
-        ];
-        let stmt_prefix_map: HashMap<TokenType, Rc<PrefixParser<Statement, T> + 'static>> =
-        hashmap![
-            Let => Rc::new(DeclarationParser { }) as Rc<PrefixParser<Statement, T>>,
-            Return => Rc::new(ReturnParser { }) as Rc<PrefixParser<Statement, T>>,
-            Do => Rc::new(DoBlockParser { }) as Rc<PrefixParser<Statement, T>>,
-            If => Rc::new(IfBlockParser { }) as Rc<PrefixParser<Statement, T>>,
-        ];
-        let item_prefix_map: HashMap<TokenType, Rc<PrefixParser<Item, T> + 'static>> =
-        hashmap![
-            Fn => Rc::new(FnDeclarationParser { }) as Rc<PrefixParser<Item, T>>,
-            Typedef => Rc::new(TypedefParser { }) as Rc<PrefixParser<Item, T>>,
-        ];
-
         Parser {
             tokenizer: tokenizer,
             lookahead: VecDeque::new(),
-            item_parsers: item_prefix_map,
-            stmt_prefix_parsers: stmt_prefix_map,
-            expr_prefix_parsers: expr_prefix_map,
-            expr_infix_parsers: expr_infix_map,
             indent_rules: Vec::new(),
         }
     }
@@ -562,12 +429,7 @@ impl<T: Tokenizer> Parser<T> {
 
     /// Get the current precedence
     fn current_precedence(&mut self) -> Precedence {
-        let looked_ahead = self.look_ahead(1).get_type();
- if let Some(infix_parser) = self.expr_infix_parsers.get(&looked_ahead).cloned() {
-            infix_parser.precedence()
-        } else {
-            Precedence::Min
-        }
+        Precedence::for_token(self.next_type(), false)
     }
 }
 

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -398,6 +398,7 @@ impl<T: Tokenizer> Parser<T> {
         use lex::TokenType::*;
         match token_type {
             Minus => Ok(UnaryOperator::Negation),
+            Plus => Ok(UnaryOperator::Addition),
             _ => Err(ParseError::UnknownOperator {
                     text: Cow::from(format!("{:?}", token_type)),
                     token_type

--- a/src/parse/symbol/expression/assign_op.rs
+++ b/src/parse/symbol/expression/assign_op.rs
@@ -32,7 +32,4 @@ impl<T: Tokenizer> InfixParser<Expression, T> for AssignOpParser {
             Box::new(right_value)));
         Ok(Expression::Assignment(Assignment::new(lvalue, Box::new(right_expr))))
     }
-    fn precedence(&self) -> Precedence {
-        Precedence::Assign
-    }
 }

--- a/src/parse/symbol/expression/assignment.rs
+++ b/src/parse/symbol/expression/assignment.rs
@@ -24,7 +24,4 @@ impl<T: Tokenizer> InfixParser<Expression, T> for AssignmentParser {
         let right = try!(right_expr.expect_value());
         Ok(Expression::Assignment(Assignment::new(ident, Box::new(right))))
     }
-    fn precedence(&self) -> Precedence {
-        Precedence::Assign
-    }
 }

--- a/src/parse/symbol/expression/fn_call.rs
+++ b/src/parse/symbol/expression/fn_call.rs
@@ -66,8 +66,4 @@ impl<T: Tokenizer> InfixParser<Expression, T> for FnCallParser {
         let call = FnCall::new(lvalue, token, call_args);
         Ok(Expression::FnCall(call))
     }
-
-    fn precedence(&self) -> Precedence {
-        Precedence::Paren
-    }
 }

--- a/src/parse/symbol/expression/mod.rs
+++ b/src/parse/symbol/expression/mod.rs
@@ -14,8 +14,6 @@ pub use self::assign_op::AssignOpParser;
 pub use self::if_expr::IfExpressionParser;
 pub use self::fn_call::FnCallParser;
 
-use std::rc::Rc;
-
 use lex::{Token, Tokenizer};
 use parse::{Parser, ParseResult};
 use ast::*;
@@ -25,26 +23,17 @@ use parse::symbol::{Precedence, InfixParser, PrefixParser};
 ///
 /// Instances of this parser return `BinaryExpression`s.
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct BinOpExprSymbol {
-    precedence: Precedence
-}
+pub struct BinOpExprSymbol { }
+
 impl<T: Tokenizer> InfixParser<Expression, T> for BinOpExprSymbol {
     /// Parses a binary operator expression.
     fn parse(&self, parser: &mut Parser<T>,
              left: Expression, token: Token) -> ParseResult<Expression> {
-        let right: Expression = try!(parser.expression(self.precedence));
+        let precedence = Precedence::for_token(token.get_type(), false);
+        let right: Expression = try!(parser.expression(precedence));
         let bin_operator = try!(parser.binary_operator(token.get_type()));
         Ok(Expression::BinaryOp(
             BinaryOperation::new(bin_operator, token, Box::new(left), Box::new(right))))
-    }
-    fn precedence(&self) -> Precedence {
-        self.precedence
-    }
-}
-impl BinOpExprSymbol {
-    /// Creates a BinOpSymbol with the given type and precedence.
-    pub fn with_precedence<T: Tokenizer>(precedence: Precedence) -> Rc<InfixParser<Expression, T>> {
-        Rc::new(BinOpExprSymbol { precedence: precedence }) as Rc<InfixParser<Expression, T>>
     }
 }
 
@@ -52,21 +41,15 @@ impl BinOpExprSymbol {
 ///
 /// Returns a unary operator with the given token type and following expression
 #[derive(Debug, PartialEq, Clone)]
-pub struct UnaryOpExprSymbol {
-    precedence: Precedence
-}
+pub struct UnaryOpExprSymbol { }
+
 impl<T: Tokenizer> PrefixParser<Expression, T> for UnaryOpExprSymbol {
     fn parse(&self,
              parser: &mut Parser<T>, token: Token) -> ParseResult<Expression> {
-        let right_expr = try!(parser.expression(self.precedence));
+        let precedence = Precedence::for_token(token.get_type(), true);
+        let right_expr = try!(parser.expression(precedence));
         let right_value = try!(right_expr.expect_value());
         let operator = try!(parser.unary_operator(token.get_type()));
         Ok(Expression::UnaryOp(UnaryOperation::new(operator, token, Box::new(right_value))))
-    }
-}
-impl UnaryOpExprSymbol {
-    /// Create a new BinaryOpSymbol parser with the given precedence
-    pub fn with_precedence<T: Tokenizer>(precedence: Precedence) -> Rc<PrefixParser<Expression, T>> {
-        Rc::new(UnaryOpExprSymbol { precedence: precedence }) as Rc<PrefixParser<Expression, T>>
     }
 }

--- a/src/parse/symbol/mod.rs
+++ b/src/parse/symbol/mod.rs
@@ -28,7 +28,6 @@ pub trait PrefixParser<E, T: Tokenizer> {
 /// Generic parser trait used to parse AST nodes of type E in the infix position.
 pub trait InfixParser<E, T: Tokenizer> {
     fn parse(&self, parser: &mut Parser<T>, left: E, token: Token) -> ParseResult<E>;
-    fn precedence(&self) -> Precedence;
 }
 
 // TODO This can't be implemented until we have a way of knowing when to stop calling

--- a/src/parse/symbol/precedence.rs
+++ b/src/parse/symbol/precedence.rs
@@ -43,7 +43,7 @@ impl Precedence {
             | SlashEquals
             | PercentEquals => Precedence::Assign,
             DoubleEquals | NotEquals => Precedence::Equality,
-            LessThanEquals | GreaterThanEquals => Precedence::EqualityCompare,
+            LeftAngle | RightAngle | LessThanEquals | GreaterThanEquals => Precedence::EqualityCompare,
             Plus | Minus => {
                 if prefix {Precedence::NumericPrefix }
                 else {Precedence::AddSub }

--- a/src/parse/symbol/precedence.rs
+++ b/src/parse/symbol/precedence.rs
@@ -1,5 +1,7 @@
 //! Symbol definitions for Pratt parsing
 
+use lex::TokenType;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Precedence {
     /// Extra value on the end
@@ -26,4 +28,30 @@ pub enum Precedence {
     Paren,
     /// Extra value on the end
     Max
+}
+
+impl Precedence {
+    /// Source of truth for precedence in parsing expressions
+    pub fn for_token(token_type: TokenType, prefix: bool) -> Precedence {
+        use self::TokenType::*;
+        match token_type {
+            Return => Precedence::Return,
+            Equals
+            | PlusEquals
+            | MinusEquals
+            | StarEquals
+            | SlashEquals
+            | PercentEquals => Precedence::Assign,
+            DoubleEquals | NotEquals => Precedence::Equality,
+            LessThanEquals | GreaterThanEquals => Precedence::EqualityCompare,
+            Plus | Minus => {
+                if prefix {Precedence::NumericPrefix }
+                else {Precedence::AddSub }
+            },
+            Star | Slash => Precedence::MulDiv,
+            Percent => Precedence::Modulo,
+            LeftParen => Precedence::Paren,
+            _ => Precedence::Min
+        }
+    }
 }

--- a/tests/compile/expression/numeric-comparisons-ok.protosnirk
+++ b/tests/compile/expression/numeric-comparisons-ok.protosnirk
@@ -4,3 +4,4 @@ fn main()
     let c: bool = 3 <= 4
     let d: bool = 4 >= 5
     let e: bool = 6 == 6
+    let f: bool = 7 != 8

--- a/tests/compile/expression/numeric-operators-ok.protosnirk
+++ b/tests/compile/expression/numeric-operators-ok.protosnirk
@@ -1,0 +1,10 @@
+// Numeric operations happen
+
+fn main()
+    let x = 1
+    let y = +x
+    let z = x - 2
+    let a = z + 1
+    let b = -z
+    let c = -b + -z
+    let d = a + b / c


### PR DESCRIPTION
This PR rewrites most parsing in `parse` to use fixed match expressions. We further move precedence information, which was stored in the parsers themselves, into the `Precedence` enum (depending on prefix vs infix). The `Precedence` enum now represents the source of truth for symbol precedence.

This PR also completes support for unary+ ("The not necessary numberical no-op operator!") and tests and _fixes_ support for unary-. 