### PR TITLE
Spans! (Closes #39)

### DIFF
--- a/src/ast/item.rs
+++ b/src/ast/item.rs
@@ -46,18 +46,25 @@ pub struct BlockFnDeclaration {
     ret_ty: TypeExpression,
     explicit_ret_ty: bool,
     block: Block,
+    span: Span
 }
 
 impl BlockFnDeclaration {
     /// Create a new FnDeclaration
-    pub fn new(ident: Identifier,
+    pub fn new(start: Location,
+               ident: Identifier,
                params: Vec<(Identifier, TypeExpression)>,
                ret_ty: TypeExpression,
                explicit_ret_ty: bool,
                block: Block)
                -> BlockFnDeclaration {
         BlockFnDeclaration {
-            ident, params, ret_ty, explicit_ret_ty, block
+            span: Span::from(start ..= block.span().end()),
+            ident,
+            params,
+            ret_ty,
+            explicit_ret_ty,
+            block
         }
     }
 
@@ -90,7 +97,7 @@ impl BlockFnDeclaration {
     }
 
     pub fn span(&self) -> Span {
-        Span::from(self.ident.span() ..= self.block.span())
+        self.span
     }
 }
 
@@ -108,9 +115,9 @@ impl Typedef {
                type_expr: TypeExpression)
                -> Typedef {
         Typedef {
+            span: Span::from(start ..= type_expr.span().end()),
             alias_ident,
-            type_expr,
-            span: Span::from(start ..= type_expr.span().end())
+            type_expr
         }
     }
 

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -8,7 +8,7 @@
 
 use std::cell::Ref;
 
-use ast::{ScopedId, Identifier};
+use ast::{ScopedId, Identifier, Span};
 
 /// Represents type expressions in protosnirk.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -21,6 +21,13 @@ impl TypeExpression {
     pub fn id(&self) -> Ref<ScopedId> {
         match self {
             &TypeExpression::Named(ref named) => named.id()
+        }
+    }
+
+    pub fn span(&self) -> Span {
+        use self::TypeExpression::*;
+        match self {
+            Named(ref n) => n.span()
         }
     }
 }
@@ -56,5 +63,9 @@ impl NamedTypeExpression {
 
     pub fn set_id<'a>(&'a self, id: ScopedId) {
         self.ident.set_id(id);
+    }
+
+    pub fn span(&self) -> Span {
+        self.ident.span()
     }
 }

--- a/src/ast/visit/walk.rs
+++ b/src/ast/visit/walk.rs
@@ -71,7 +71,7 @@ pub fn walk_if_block<V>(visitor: &mut V, if_block: &IfBlock)
         visitor.visit_expression(cond.condition());
         visitor.visit_block(cond.block());
     }
-    if let Some(&(_, ref block)) = if_block.else_block() {
+    if let Some(ref block) = if_block.else_block() {
         visitor.visit_block(block);
     }
 }

--- a/src/check/errors.rs
+++ b/src/check/errors.rs
@@ -1,6 +1,6 @@
 //! Result types for Verification
 
-use lex::{Token};
+use lex::Span;
 
 /// Compiler error returned by an expression verifier.
 ///
@@ -8,26 +8,19 @@ use lex::{Token};
 /// compiler options. Errors are collected in an `ErrorCollector`.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct CheckerError {
-    //err: ErrorCode,
-    offender: Token,
-    references: Vec<Token>,
+    spans: Vec<Span>,
     text: String,
 }
 impl CheckerError {
-    pub fn new(offender: Token,
-               references: Vec<Token>,
+    pub fn new(spans: Vec<Span>,
                text: String) -> CheckerError {
-        CheckerError {
-            offender: offender,
-            references: references,
-            text: text,
-        }
+        CheckerError { spans, text }
     }
-    pub fn offender(&self) -> &Token {
-        &self.offender
+    pub fn offender(&self) -> Option<Span> {
+        self.spans.first().cloned()
     }
-    pub fn references(&self) -> &[Token] {
-        &self.references
+    pub fn spans(&self) -> &[Span] {
+        &self.spans
     }
     pub fn text(&self) -> &str {
         &self.text

--- a/src/compile/module_compiler.rs
+++ b/src/compile/module_compiler.rs
@@ -295,7 +295,7 @@ impl<'ctx, 'b, M> StatementVisitor for ModuleCompiler<'ctx, 'b, M>
 
         trace!("Finished checking conditions");
         // If there's an else, check that too
-        if let Some(&(_, ref else_block)) = if_block.else_block() {
+        if let Some(ref else_block) = if_block.else_block() {
             trace!("Checking else block");
             self.visit_block(else_block);
             if valued_if {
@@ -363,7 +363,7 @@ impl<'ctx, 'b, M> ExpressionVisitor for ModuleCompiler<'ctx, 'b, M>
 
     fn visit_literal_expr(&mut self, literal: &Literal) {
         use ast::LiteralValue;
-        trace!("Checking literal {}", literal.token().text());
+        trace!("Checking literal {}", literal.text());
         let (literal_value, literal_type) = match literal.value() {
             &LiteralValue::Bool(b) => {
                 let bool_value = if b { 1u64 } else { 0u64 };

--- a/src/identify/types/expr_typographer.rs
+++ b/src/identify/types/expr_typographer.rs
@@ -204,7 +204,7 @@ impl<'err, 'builder, 'graph> StatementVisitor
             }
         }
 
-        if let Some(&(_, ref block)) = if_block.else_block() {
+        if let Some(ref block) = if_block.else_block() {
             trace!("Checking block else");
             self.visit_block(block);
             if valued_if {
@@ -477,8 +477,7 @@ impl<'err, 'builder, 'graph> ExpressionVisitor
         if fn_ix.is_none() {
             debug!("Could not find type of function {}", fn_call.text());
             self.errors.add_error(CheckerError::new(
-                fn_call.token().clone(),
-                vec![],
+                vec![fn_call.span()],
                 format!("Unknown function {}", fn_call.text())
             ));
             return

--- a/src/identify/types/item_namer.rs
+++ b/src/identify/types/item_namer.rs
@@ -101,8 +101,7 @@ impl<'err, 'builder> ItemVisitor for ItemTypeIdentifier<'err, 'builder> {
             // But we can do this in the type graph.
             // I'd rather catch this one faster, it's also way less likely.
             self.errors.add_error(CheckerError::new(
-                typedef.token().clone(),
-                vec![],
+                vec![typedef.span()],
                 format!("Circular definiton of typedef {}", typedef.name())
             ));
         }

--- a/src/identify/types/type_identifier.rs
+++ b/src/identify/types/type_identifier.rs
@@ -35,8 +35,7 @@ impl<'err, 'builder> TypeVisitor for TypeIdentifier<'err, 'builder> {
         else {
             debug!("Did not have type_id for named type {}", named_ty.name());
             self.errors.add_error(CheckerError::new(
-                named_ty.ident().token().clone(),
-                vec![],
+                vec![named_ty.span()],
                 format!("Unknown type {}", named_ty.name())
             ));
         }

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -1,13 +1,15 @@
 //! Contains the lexer which reads protosnirk syntax.
 
+mod span;
 mod token;
 pub mod tokens;
 mod textiter;
 pub mod tokenizer;
 
+pub use self::span::{Location, Span};
 pub use self::token::{Token, TokenData};
 pub use self::tokens::TokenType;
-pub use self::textiter::{TextLocation, TextIter, PeekTextIter};
+pub use self::textiter::{TextIter, PeekTextIter};
 pub use self::tokenizer::{Tokenizer, IterTokenizer};
 
 /// Type representing a borrowed or owned string

--- a/src/lex/span.rs
+++ b/src/lex/span.rs
@@ -1,0 +1,180 @@
+//! Position information for the AST
+
+use std::fmt::{Display, Debug, Formatter, Result as FmtResult};
+use std::cmp::{PartialOrd, Ord, Ordering};
+
+/// Represents the location of a single `Token`.
+#[derive(PartialEq, Eq, Clone, Copy, Hash, Default)]
+pub struct Location {
+    /// Index within source text
+    index: u32,
+    /// Line within source text
+    line: u32,
+    /// Column within source text
+    column: u32,
+}
+
+impl Location {
+    /// Creates a new `Location` with the given index, line, column, and length.
+    pub fn of() -> LocationBuilder {
+        LocationBuilder { index: 0, line: 0, column: 0 }
+    }
+
+    /// The starting index of the token within the source string.
+    pub fn index(&self) -> u32 {
+        self.index
+    }
+
+    /// The line on which the token appears in the source string (1-indexed).
+    pub fn line(&self) -> u32 {
+        self.line
+    }
+
+    /// The column on which the token appears in the source string (1-indexed).
+    pub fn column(&self) -> u32 {
+        self.column
+    }
+}
+
+impl Debug for Location {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "(line: {}, col: {})", self.line, self.column)
+    }
+}
+
+impl Display for Location {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "line {}, column {}", self.line, self.column)
+    }
+}
+
+/// Builder for constructing locations via `Location::build()`
+#[derive(Debug, PartialEq)]
+pub struct LocationBuilder {
+    index: u32,
+    line: u32,
+    column: u32
+}
+
+impl LocationBuilder {
+    pub fn index(&mut self, index: u32) -> &mut Self {
+        self.index = index;
+        self
+    }
+
+    pub fn line(&mut self, line: u32) -> &mut Self {
+        self.line = line;
+        self
+    }
+
+    pub fn column(&mut self, column: u32) -> &mut Self {
+        self.column = column;
+        self
+    }
+
+    pub fn build(&mut self) -> Location {
+        Location { index: self.index, line: self.line, column: self.column }
+    }
+}
+
+impl PartialOrd for Location {
+    fn partial_cmp(&self, other: &Location) -> Option<Ordering> {
+        self.index.partial_cmp(&other.index)
+    }
+}
+
+impl Ord for Location {
+    fn cmp(&self, other: &Location) -> Ordering {
+        self.index.cmp(&other.index)
+    }
+}
+
+/// Represents an area of text which is taken up by a node in the AST.
+///
+/// Spans may be multiline or represent an expression which uses part of a line.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Default)]
+pub struct Span {
+    /// Location of the first token in the span
+    start: Location,
+    /// Location of the last token in the span
+    end: Location
+}
+
+impl Span {
+    /// Creates a new span between the two given points.
+    pub fn between(start: Location, end: Location) -> Span {
+        debug_assert!(end > start,
+                      "Attempted to create invalid span ({}, {})",
+                      start, end);
+        Span { start, end }
+    }
+
+    /// Creates a new span starting from a point across a number of characters in a line
+    pub fn in_line(start: Location, offset: u32) -> Span {
+        Span {
+            start,
+            end: Location {
+                index: start.index + offset,
+                line: start.line,
+                column: start.column + offset
+            }
+        }
+    }
+
+    /// The starting token's location in the span.
+    pub fn start(&self) -> Location {
+        self.start
+    }
+
+    /// The ending token's location in the span.
+    pub fn end(&self) -> Location {
+        self.end
+    }
+
+    /// Total length of this span (in terms of characters)
+    pub fn len(&self) -> u32 {
+        self.end.index - self.start.index
+    }
+
+    // Number of lines in this span
+    pub fn lines(&self) -> u32 {
+        self.end.line - self.start.line
+    }
+
+    pub fn chars(&self) -> u32 {
+        self.end.index - self.start.index
+    }
+
+    /// Whether this span encompasses multiple lines
+    pub fn is_multiline(&self) -> bool {
+        self.lines() > 0
+    }
+
+    pub fn is_multichar(&self) -> bool {
+        self.chars() > 0
+    }
+}
+
+impl Display for Span {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        if self.is_multiline() {
+            write!(f, "{} to {}", self.start, self.end)
+        }
+        else {
+            write!(f, "line {}, column {} to {}",
+                   self.start.line, self.start.column, self.end.column)
+        }
+    }
+}
+
+impl PartialOrd for Span {
+    fn partial_cmp(&self, other: &Span) -> Option<Ordering> {
+        (self.start.index, self.end.index).partial_cmp(&(other.start.index, other.end.index))
+    }
+}
+
+impl Ord for Span {
+    fn cmp(&self, other: &Span) -> Ordering {
+        (self.start.index, self.end.index).cmp(&(other.start.index, other.end.index))
+    }
+}

--- a/src/lex/textiter.rs
+++ b/src/lex/textiter.rs
@@ -2,19 +2,14 @@
 
 use std::iter::{Iterator, Peekable};
 
-/// Structure representing the location of some character or string in a text.
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash, Default)]
-pub struct TextLocation {
-    pub index: usize,
-    pub line: usize,
-    pub column: usize
-}
+use lex::Location;
 
 /// A specialized iterator (for tokenizing) which also implements `peek()`
 /// and keeps track of its location.
 pub trait TextIter : Iterator {
     fn peek(&mut self) -> Option<char>;
-    fn location(&self) -> TextLocation;
+    /// Current location of the iterator.
+    fn location(&self) -> Location;
 }
 
 /// A `TextIter` which uses an internal `Peekable<T>`.
@@ -23,11 +18,11 @@ pub struct PeekTextIter<T> where T: Iterator<Item=char> {
     /// Iterator which does most of the work
     iter: Peekable<T>,
     /// Current line in the source
-    current_line: usize,
+    current_line: u32,
     /// Current column in the source
-    current_column: usize,
+    current_column: u32,
     /// Current byte in the source
-    current_char: usize
+    current_char: u32
 }
 impl<T: Iterator<Item=char>> PeekTextIter<T> {
     pub fn new(iter: Peekable<T>) -> PeekTextIter<T> {
@@ -44,12 +39,13 @@ impl<T: Iterator<Item=char>> TextIter for PeekTextIter<T> {
     fn peek(&mut self) -> Option<char> {
         self.iter.peek().cloned()
     }
-    fn location(&self) -> TextLocation {
-        TextLocation {
-            index: self.current_char,
-            line: self.current_line,
-            column: self.current_column
-        }
+
+    fn location(&self) -> Location {
+        Location::of()
+            .index(self.current_char)
+            .line(self.current_line)
+            .column(self.current_column)
+            .build()
     }
 }
 

--- a/src/lex/token.rs
+++ b/src/lex/token.rs
@@ -40,7 +40,7 @@ impl Token {
 
     /// Get the span of this token including its source text
     pub fn span(&self) -> Span {
-        Span::in_line(self.location, self.text.len() as u32)
+        Span::from(self.location ..= self.location.offset(self.text.len() as u32))
     }
 
     /// Creates a new token with the given information.

--- a/src/lex/token.rs
+++ b/src/lex/token.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
 use std::fmt::Result as FmtResult;
 
-use lex::{TextLocation, CowStr};
+use lex::{Location, Span, CowStr};
 
 /// A token returned by the tokenizer.
 ///
@@ -15,11 +15,11 @@ use lex::{TextLocation, CowStr};
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct Token {
     /// Location of the token in a file
-    pub(crate) location: TextLocation,
+    location: Location,
     /// Text of the token at that location
-    pub(crate) text: CowStr,
+    text: CowStr,
     /// Additional data (type/literal) provided by the lexer
-    pub(crate) data: TokenData
+    data: TokenData
 }
 
 impl Token {
@@ -28,23 +28,30 @@ impl Token {
         &self.text
     }
 
+    /// The data associated with this token
     pub fn data(&self) -> &TokenData {
         &self.data
     }
 
-    pub fn location(&self) -> &TextLocation {
-        &self.location
+    /// The location of this token where it starts in its source text
+    pub fn location(&self) -> Location {
+        self.location
     }
 
+    /// Get the span of this token including its source text
+    pub fn span(&self) -> Span {
+        Span::in_line(self.location, self.text.len() as u32)
+    }
+
+    /// Creates a new token with the given information.
     pub fn new<T: Into<CowStr>>(text: T,
-                                location: TextLocation,
+                                location: Location,
                                 data: TokenData) -> Token {
         Token { text: text.into(), location, data }
     }
 
     /// Creates a new token representing an identifier
-    #[inline]
-    pub fn new_ident<T: Into<CowStr>>(text: T, location: TextLocation) -> Token {
+    pub fn new_ident<T: Into<CowStr>>(text: T, location: Location) -> Token {
         Token {
             text: text.into(),
             data: TokenData::Ident,
@@ -53,8 +60,7 @@ impl Token {
     }
 
     /// Creates a new token representing an indentation
-    #[inline]
-    pub fn new_indent(location: TextLocation) -> Token {
+    pub fn new_indent(location: Location) -> Token {
         Token {
             text: Cow::Borrowed(""),
             data: TokenData::BeginBlock,
@@ -63,8 +69,7 @@ impl Token {
     }
 
     /// Creates a new token representing an outdentation
-    #[inline]
-    pub fn new_outdent(location: TextLocation) -> Token {
+    pub fn new_outdent(location: Location) -> Token {
         Token {
             text: Cow::Borrowed(""),
             data: TokenData::EndBlock,
@@ -73,8 +78,7 @@ impl Token {
     }
 
     /// Creates a new token representing an EOF
-    #[inline]
-    pub fn new_eof(location: TextLocation) -> Token {
+    pub fn new_eof(location: Location) -> Token {
         Token {
             text: Cow::Borrowed(""),
             data: TokenData::EOF,

--- a/src/lex/tokens.rs
+++ b/src/lex/tokens.rs
@@ -77,7 +77,7 @@ macro_rules! declare_tokens {
                             $(
                                 $kw_val => TokenType::$kw_name,
                             )*
-                            _ => unreachable!("Invalid token text for kw")
+                           _ => unreachable!("Invalid token text for kw")
                         }
                     },
                     TokenData::Symbol => {

--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -11,7 +11,8 @@ pub type ParseResult<T> = Result<T, ParseError>;
 pub enum ParseError {
     ExpectedToken {
         expected: TokenType,
-        got: Token
+        got: TokenType,
+        token: Token
     },
     ExpectedExpression {
         expected: ExpectedNextType,

--- a/src/parse/symbol/expression/assign_op.rs
+++ b/src/parse/symbol/expression/assign_op.rs
@@ -27,7 +27,6 @@ impl<T: Tokenizer> InfixParser<Expression, T> for AssignOpParser {
         // We parse it here into an expanded expression.
         let right_expr = Expression::BinaryOp(BinaryOperation::new(
             operator,
-            token,
             Box::new(Expression::VariableRef(lvalue.clone())),
             Box::new(right_value)));
         Ok(Expression::Assignment(Assignment::new(lvalue, Box::new(right_expr))))

--- a/src/parse/symbol/expression/fn_call.rs
+++ b/src/parse/symbol/expression/fn_call.rs
@@ -1,6 +1,6 @@
 //! Function call - inline `(`
 
-use lex::{Token, Tokenizer, TokenType};
+use lex::{Token, Tokenizer, TokenType, Span};
 use ast::*;
 use parse::{Parser, ParseResult, ParseError, IndentationRule};
 use parse::symbol::{InfixParser, Precedence};
@@ -20,7 +20,7 @@ impl<T: Tokenizer> InfixParser<Expression, T> for FnCallParser {
         trace!("Parsing a function call of {:?}", left);
         debug_assert!(token.get_type() == TokenType::LeftParen,
             "FnCallParser: called on token {:?}", token);
-
+        let start = token.location();
         let lvalue = try!(left.expect_identifier());
 
         let mut call_args = Vec::new();
@@ -63,7 +63,8 @@ impl<T: Tokenizer> InfixParser<Expression, T> for FnCallParser {
                 arg_name = true;
             }
         }
-        let call = FnCall::new(lvalue, token, call_args);
+        let end = parser.peek().location();
+        let call = FnCall::new(Span::from(start ..= end), lvalue, call_args);
         Ok(Expression::FnCall(call))
     }
 }

--- a/src/parse/symbol/expression/identifier.rs
+++ b/src/parse/symbol/expression/identifier.rs
@@ -2,7 +2,7 @@
 
 // This is gonna be merged with lvalue parsers
 
-use lex::{Token, TokenData, Tokenizer};
+use lex::{Token, Tokenizer};
 use parse::{Parser, ParseResult};
 use ast::*;
 use parse::symbol::PrefixParser;
@@ -17,17 +17,7 @@ use parse::symbol::PrefixParser;
 #[derive(Debug)]
 pub struct IdentifierParser { }
 impl<T: Tokenizer> PrefixParser<Expression, T> for IdentifierParser {
-    fn parse(&self, _parser: &mut Parser<T>, mut token: Token) -> ParseResult<Expression> {
-        if token.text() == "true" {
-            token.data = TokenData::BoolLiteral(true);
-            Ok(Expression::Literal(Literal::new(token, LiteralValue::Bool(true))))
-        }
-        else if token.text() == "false" {
-            token.data = TokenData::BoolLiteral(false);
-            Ok(Expression::Literal(Literal::new(token, LiteralValue::Bool(false))))
-        }
-        else {
-            Ok(Expression::VariableRef(Identifier::new(token)))
-        }
+    fn parse(&self, _parser: &mut Parser<T>, token: Token) -> ParseResult<Expression> {
+        Ok(Expression::VariableRef(Identifier::new(token)))
     }
 }

--- a/src/parse/symbol/expression/if_expr.rs
+++ b/src/parse/symbol/expression/if_expr.rs
@@ -24,6 +24,7 @@ impl<T: Tokenizer> PrefixParser<Expression, T> for IfExpressionParser {
         debug_assert!(token.text() == "if",
             "Invlaid token {:?} in IfExpressionParser", token);
         trace!("Parsing conditional of if expression");
+        let start = token.location();
         let condition = try!(parser.expression(Precedence::Min));
         trace!("Parsed if conditional");
         try!(parser.consume_type(TokenType::InlineArrow));
@@ -33,7 +34,7 @@ impl<T: Tokenizer> PrefixParser<Expression, T> for IfExpressionParser {
         try!(parser.consume_type(TokenType::Else));
         trace!("Parsing else half of conditional");
         let else_expr = try!(parser.expression(Precedence::Min));
-        let if_expr = IfExpression::new(token,
+        let if_expr = IfExpression::new(start,
                                         Box::new(condition),
                                         Box::new(true_expr),
                                         Box::new(else_expr));

--- a/src/parse/symbol/expression/literal.rs
+++ b/src/parse/symbol/expression/literal.rs
@@ -18,10 +18,13 @@ impl<T: Tokenizer> PrefixParser<Expression, T> for LiteralParser {
         match *token.data() {
             TokenData::NumberLiteral(val) =>
                 Ok(Expression::Literal(Literal::new(token, LiteralValue::Float(val)))),
+            TokenData::BoolLiteral(b) =>
+                Ok(Expression::Literal(Literal::new(token, LiteralValue::Bool(b)))),
             _ => Err(ParseError::ExpectedToken {
-                    expected: TokenType::Literal,
-                    got: token
-                })
+                expected: TokenType::Literal,
+                got: token.get_type(),
+                token: token
+            })
         }
     }
 }

--- a/src/parse/symbol/expression/mod.rs
+++ b/src/parse/symbol/expression/mod.rs
@@ -33,7 +33,7 @@ impl<T: Tokenizer> InfixParser<Expression, T> for BinOpExprSymbol {
         let right: Expression = try!(parser.expression(precedence));
         let bin_operator = try!(parser.binary_operator(token.get_type()));
         Ok(Expression::BinaryOp(
-            BinaryOperation::new(bin_operator, token, Box::new(left), Box::new(right))))
+            BinaryOperation::new(bin_operator, Box::new(left), Box::new(right))))
     }
 }
 
@@ -46,10 +46,11 @@ pub struct UnaryOpExprSymbol { }
 impl<T: Tokenizer> PrefixParser<Expression, T> for UnaryOpExprSymbol {
     fn parse(&self,
              parser: &mut Parser<T>, token: Token) -> ParseResult<Expression> {
+        let start = token.location();
         let precedence = Precedence::for_token(token.get_type(), true);
         let right_expr = try!(parser.expression(precedence));
         let right_value = try!(right_expr.expect_value());
         let operator = try!(parser.unary_operator(token.get_type()));
-        Ok(Expression::UnaryOp(UnaryOperation::new(operator, token, Box::new(right_value))))
+        Ok(Expression::UnaryOp(UnaryOperation::new(start, operator, Box::new(right_value))))
     }
 }

--- a/src/parse/symbol/item/function.rs
+++ b/src/parse/symbol/item/function.rs
@@ -22,6 +22,7 @@ impl<T: Tokenizer> PrefixParser<Item, T> for FnDeclarationParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Item> {
         debug_assert!(token.get_type() == TokenType::Fn,
             "Unexpected token {:?} to fn parser", token);
+        let start = token.location();
         let name = try!(parser.lvalue());
 
         // Args
@@ -74,7 +75,7 @@ impl<T: Tokenizer> PrefixParser<Item, T> for FnDeclarationParser {
         try!(parser.consume_type(TokenType::BeginBlock));
         let block = try!(parser.block());
         Ok(Item::BlockFnDeclaration(BlockFnDeclaration::new(
-            token, name, params, return_ty, explicit, block
+            start, name, params, return_ty, explicit, block
         )))
     }
 }

--- a/src/parse/symbol/item/typedef.rs
+++ b/src/parse/symbol/item/typedef.rs
@@ -18,7 +18,7 @@ impl<T: Tokenizer> PrefixParser<Item, T> for TypedefParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Item> {
         debug_assert!(token.get_type() == TokenType::Typedef,
             "Unexpected token {:?} to type alias parser", token);
-
+        let start = token.location();
         let name = try!(parser.lvalue());
 
         try!(parser.consume_type(TokenType::Equals));
@@ -26,7 +26,7 @@ impl<T: Tokenizer> PrefixParser<Item, T> for TypedefParser {
         let type_ = try!(parser.type_expr());
 
         Ok(Item::Typedef(Typedef::new(
-            token, name, type_
+            start, name, type_
         )))
     }
 }

--- a/src/parse/symbol/statement/declaration.rs
+++ b/src/parse/symbol/statement/declaration.rs
@@ -21,6 +21,7 @@ impl<T: Tokenizer> PrefixParser<Statement, T> for DeclarationParser {
         debug_assert!(token.get_type() == TokenType::Let,
                       "Let parser called with non-let token {:?}", token);
         trace!("Parsing declaration for {}", token);
+        let start = token.location();
         let is_mutable = parser.next_type() == TokenType::Mut;
         if is_mutable {
             parser.consume();
@@ -43,7 +44,7 @@ impl<T: Tokenizer> PrefixParser<Statement, T> for DeclarationParser {
         let value = try!(value_expr.expect_value());
         trace!("Got rvalue {:?}", value);
         Ok(Statement::Declaration(Declaration::new(
-            name, is_mutable, decl_type, Box::new(value)
+            start, name, is_mutable, decl_type, Box::new(value)
         )))
     }
 }

--- a/src/parse/symbol/statement/do_block.rs
+++ b/src/parse/symbol/statement/do_block.rs
@@ -21,19 +21,20 @@ pub struct DoBlockParser { }
 impl<T: Tokenizer> PrefixParser<Statement, T> for DoBlockParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Statement> {
         debug_assert!(token.text() == "do",
-            "Invalid token {:?} in DoBlockParser", token);
+                      "Invalid token {:?} in DoBlockParser", token);
+        let start = token.location();
         if parser.next_type() == TokenType::BeginBlock {
             parser.consume();
             let block = try!(parser.block());
-            Ok(Statement::DoBlock(DoBlock::new(token, Box::new(block))))
+            Ok(Statement::DoBlock(DoBlock::new(start, Box::new(block))))
         }
         else { // Allow for inline form `do <expr>`
             // Parsing a statement here may be useless
             // We might want only expressions.
             // Also allows for do do do do x
             let stmt = try!(parser.statement());
-            let block = Block::new(vec![stmt]);
-            Ok(Statement::DoBlock(DoBlock::new(token, Box::new(block))))
+            let block = Block::new(stmt.span().start(), vec![stmt]);
+            Ok(Statement::DoBlock(DoBlock::new(start, Box::new(block))))
         }
     }
 }

--- a/src/parse/symbol/statement/return_stmt.rs
+++ b/src/parse/symbol/statement/return_stmt.rs
@@ -18,17 +18,18 @@ impl<T: Tokenizer> PrefixParser<Statement, T> for ReturnParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Statement> {
         debug_assert!(token.text() == tokens::Return,
                       "Return parser called with non-return {:?}", token);
+        let start = token.location();
         // If the next statement is on a newline then empty return.
         // Also empty return if next token is deindent
         // Should also check for an indent block to ensure sprious indentation is an error.
         if parser.peek_is_newline(&token) {
-            return Ok(Statement::Return(Return::new(token, None)))
+            return Ok(Statement::Return(Return::new(start, None)))
         }
         else if parser.peek().get_type() == TokenType::EOF {
-            return Ok(Statement::Return(Return::new(token, None)))
+            return Ok(Statement::Return(Return::new(start, None)))
         }
         let inner_expr = try!(parser.expression(Precedence::Return));
         let inner = try!(inner_expr.expect_value());
-        Ok(Statement::Return(Return::new(token, Box::new(inner))))
+        Ok(Statement::Return(Return::new(start, Box::new(inner))))
     }
 }


### PR DESCRIPTION
This PR rewrites the AST to use a `Span` type instead of occasionally storing tokens!

- Adds `Location` and `Span` in `lex`
- Removes some of the last of the public struct fields
- All AST nodes have a `Span` instead of occasionally having tokens, and are sometimes created with a start `Location` (+ children's ending)
- Checker errors use `Span`s instead of a source `Token`s
- Identify errors can include `Span` info of previous variable definitions