### PR TITLE
Rename `Token::location()` -> `Token::start()`

### DIFF
--- a/src/lex/token.rs
+++ b/src/lex/token.rs
@@ -15,7 +15,7 @@ use lex::{Location, Span, CowStr};
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct Token {
     /// Location of the token in a file
-    location: Location,
+    start: Location,
     /// Text of the token at that location
     text: CowStr,
     /// Additional data (type/literal) provided by the lexer
@@ -34,55 +34,59 @@ impl Token {
     }
 
     /// The location of this token where it starts in its source text
-    pub fn location(&self) -> Location {
-        self.location
+    pub fn start(&self) -> Location {
+        self.start
+    }
+
+    pub fn end(&self) -> Location {
+        self.start.offset(self.text.len() as u32)
     }
 
     /// Get the span of this token including its source text
     pub fn span(&self) -> Span {
-        Span::from(self.location ..= self.location.offset(self.text.len() as u32))
+        Span::from(self.start ..= self.start.offset(self.text.len() as u32))
     }
 
     /// Creates a new token with the given information.
     pub fn new<T: Into<CowStr>>(text: T,
-                                location: Location,
+                                start: Location,
                                 data: TokenData) -> Token {
-        Token { text: text.into(), location, data }
+        Token { text: text.into(), start, data }
     }
 
     /// Creates a new token representing an identifier
-    pub fn new_ident<T: Into<CowStr>>(text: T, location: Location) -> Token {
+    pub fn new_ident<T: Into<CowStr>>(text: T, start: Location) -> Token {
         Token {
             text: text.into(),
             data: TokenData::Ident,
-            location: location
+            start
         }
     }
 
     /// Creates a new token representing an indentation
-    pub fn new_indent(location: Location) -> Token {
+    pub fn new_indent(start: Location) -> Token {
         Token {
             text: Cow::Borrowed(""),
             data: TokenData::BeginBlock,
-            location: location
+            start
         }
     }
 
     /// Creates a new token representing an outdentation
-    pub fn new_outdent(location: Location) -> Token {
+    pub fn new_outdent(start: Location) -> Token {
         Token {
             text: Cow::Borrowed(""),
             data: TokenData::EndBlock,
-            location: location
+            start
         }
     }
 
     /// Creates a new token representing an EOF
-    pub fn new_eof(location: Location) -> Token {
+    pub fn new_eof(start: Location) -> Token {
         Token {
             text: Cow::Borrowed(""),
             data: TokenData::EOF,
-            location: location
+            start
         }
     }
 }

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -46,7 +46,7 @@ impl<T: Tokenizer> Parser<T> {
     // line
     pub fn peek_is_newline(&mut self, current: &Token) -> bool {
         let (indent, peeked) = self.peek_indented();
-        indent || peeked.location().line() > current.location().line()
+        indent || peeked.start().line() > current.start().line()
     }
 
     /// Consumes the next token from the tokenizer.
@@ -320,7 +320,7 @@ impl<T: Tokenizer> Parser<T> {
     ///
     /// Block parsing assumes the `BeginBlock` token has already been consumed.
     pub fn block(&mut self) -> Result<Block, ParseError> {
-        let start = self.peek().location();
+        let start = self.peek().start();
         let mut found = Vec::new();
         loop {
             let next_type = self.next_type();
@@ -421,14 +421,14 @@ impl<T: Tokenizer> Parser<T> {
 
     /// Parse a program and verify it for errors
     pub fn parse_unit(&mut self) -> Result<Unit, ParseError> {
-        let start = self.peek().location();
+        let start = self.peek().start();
         let mut items = Vec::with_capacity(10);
         while self.next_type() != TokenType::EOF {
             let item = try!(self.item());
             trace!("Parsed an item");
             items.push(item);
         }
-        let end = self.peek().location();
+        let end = self.peek().end();
         trace!("Parsed {} items", items.len());
         let unit = Unit::new(Span::from(start ..= end), items);
         Ok(unit)

--- a/src/parse/parsers/expression/fn_call.rs
+++ b/src/parse/parsers/expression/fn_call.rs
@@ -20,7 +20,7 @@ impl<T: Tokenizer> InfixParser<Expression, T> for FnCallParser {
         trace!("Parsing a function call of {:?}", left);
         debug_assert!(token.get_type() == TokenType::LeftParen,
             "FnCallParser: called on token {:?}", token);
-        let start = token.location();
+        let start = token.start();
         let lvalue = try!(left.expect_identifier());
 
         let mut call_args = Vec::new();
@@ -63,7 +63,7 @@ impl<T: Tokenizer> InfixParser<Expression, T> for FnCallParser {
                 arg_name = true;
             }
         }
-        let end = parser.peek().location();
+        let end = parser.peek().end();
         let call = FnCall::new(Span::from(start ..= end), lvalue, call_args);
         Ok(Expression::FnCall(call))
     }

--- a/src/parse/parsers/expression/if_expr.rs
+++ b/src/parse/parsers/expression/if_expr.rs
@@ -24,7 +24,7 @@ impl<T: Tokenizer> PrefixParser<Expression, T> for IfExpressionParser {
         debug_assert!(token.text() == "if",
             "Invlaid token {:?} in IfExpressionParser", token);
         trace!("Parsing conditional of if expression");
-        let start = token.location();
+        let start = token.start();
         let condition = try!(parser.expression(Precedence::Min));
         trace!("Parsed if conditional");
         try!(parser.consume_type(TokenType::InlineArrow));

--- a/src/parse/parsers/expression/mod.rs
+++ b/src/parse/parsers/expression/mod.rs
@@ -46,7 +46,7 @@ pub struct UnaryOpExprSymbol { }
 impl<T: Tokenizer> PrefixParser<Expression, T> for UnaryOpExprSymbol {
     fn parse(&self,
              parser: &mut Parser<T>, token: Token) -> ParseResult<Expression> {
-        let start = token.location();
+        let start = token.start();
         let precedence = Precedence::for_token(token.get_type(), true);
         let right_expr = try!(parser.expression(precedence));
         let right_value = try!(right_expr.expect_value());

--- a/src/parse/parsers/item/function.rs
+++ b/src/parse/parsers/item/function.rs
@@ -22,7 +22,7 @@ impl<T: Tokenizer> PrefixParser<Item, T> for FnDeclarationParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Item> {
         debug_assert!(token.get_type() == TokenType::Fn,
             "Unexpected token {:?} to fn parser", token);
-        let start = token.location();
+        let start = token.start();
         let name = try!(parser.lvalue());
 
         // Args
@@ -68,7 +68,7 @@ impl<T: Tokenizer> PrefixParser<Item, T> for FnDeclarationParser {
         else {
             (TypeExpression::Named(NamedTypeExpression::new(Identifier::new(
                 Token::new_ident("()",
-                        name.token().location().clone())))), false)
+                        name.token().start().clone())))), false)
         };
 
         // This is gonna require a comment in the place of Python's `pass`.

--- a/src/parse/parsers/item/typedef.rs
+++ b/src/parse/parsers/item/typedef.rs
@@ -18,7 +18,7 @@ impl<T: Tokenizer> PrefixParser<Item, T> for TypedefParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Item> {
         debug_assert!(token.get_type() == TokenType::Typedef,
             "Unexpected token {:?} to type alias parser", token);
-        let start = token.location();
+        let start = token.start();
         let name = try!(parser.lvalue());
 
         try!(parser.consume_type(TokenType::Equals));

--- a/src/parse/parsers/statement/declaration.rs
+++ b/src/parse/parsers/statement/declaration.rs
@@ -21,7 +21,7 @@ impl<T: Tokenizer> PrefixParser<Statement, T> for DeclarationParser {
         debug_assert!(token.get_type() == TokenType::Let,
                       "Let parser called with non-let token {:?}", token);
         trace!("Parsing declaration for {}", token);
-        let start = token.location();
+        let start = token.start();
         let is_mutable = parser.next_type() == TokenType::Mut;
         if is_mutable {
             parser.consume();

--- a/src/parse/parsers/statement/do_block.rs
+++ b/src/parse/parsers/statement/do_block.rs
@@ -22,7 +22,7 @@ impl<T: Tokenizer> PrefixParser<Statement, T> for DoBlockParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Statement> {
         debug_assert!(token.text() == "do",
                       "Invalid token {:?} in DoBlockParser", token);
-        let start = token.location();
+        let start = token.start();
         if parser.next_type() == TokenType::BeginBlock {
             parser.consume();
             let block = try!(parser.block());

--- a/src/parse/parsers/statement/if_block.rs
+++ b/src/parse/parsers/statement/if_block.rs
@@ -25,7 +25,7 @@ impl<T: Tokenizer> PrefixParser<Statement, T> for IfBlockParser {
         debug_assert!(token.get_type() == TokenType::If,
             "Invalid token {:?} in IfBlockParser", token);
         trace!("Parsing conditional of if statement");
-        let block_start = token.location();
+        let block_start = token.start();
         let condition = try!(parser.expression(Precedence::Min));
         trace!("Parsed conditional");
         if parser.peek().get_type() == TokenType::InlineArrow {
@@ -58,7 +58,7 @@ impl<T: Tokenizer> PrefixParser<Statement, T> for IfBlockParser {
                 return Ok(Statement::IfBlock(IfBlock::new(block_start, conditionals, None)))
             }
             let else_token = parser.consume(); // else token
-            let cond_start = else_token.location();
+            let cond_start = else_token.start();
             trace!("Got an else token {:?}", else_token);
             // we have else \+ ... so we have an else block
             if parser.next_type() == TokenType::BeginBlock {

--- a/src/parse/parsers/statement/return_stmt.rs
+++ b/src/parse/parsers/statement/return_stmt.rs
@@ -18,7 +18,7 @@ impl<T: Tokenizer> PrefixParser<Statement, T> for ReturnParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Statement> {
         debug_assert!(token.text() == tokens::Return,
                       "Return parser called with non-return {:?}", token);
-        let start = token.location();
+        let start = token.start();
         // If the next statement is on a newline then empty return.
         // Also empty return if next token is deindent
         // Should also check for an indent block to ensure sprious indentation is an error.


### PR DESCRIPTION
Tokens keep track of their starting location and we figure out the end location (most of the time) via the length of their captured text. However, in the case of things on the AST that use more than one token (i.e. most things), we want the `Span` to encompass the start of the first token to the end of the last token. This PR fixes that by splitting `Token::location() -> Location` into `Token::start()` and `Token::end()`.